### PR TITLE
ci: add basic linux ci setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,4 +6,6 @@ jobs:
         steps:
             - 
                 name: setup-env
-                run: ./scripts/install-ubuntu.sh
+                run: | 
+                    cd ${{github.workspace}}
+                    ./scripts/install-ubuntu.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,4 +6,4 @@ jobs:
         steps:
             - 
                 name: setup-env
-                run: cd ~ && ${{github.workspace}}/scripts/install-ubuntu.sh
+                run: cd ~ && ls ${{github.workspace}} && ${{github.workspace}}/scripts/install-ubuntu.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,4 @@ jobs:
         steps:
             - 
                 name: setup-env
-                run: | 
-                    cd ${{github.workspace}}
-                    ./scripts/install-ubuntu.sh
+                run: cd ~ && ${{github.workspace}}/scripts/install-ubuntu.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,4 +7,4 @@ jobs:
             - uses: actions/checkout@v3
             - 
                 name: setup-env
-                run: cd ~ && ${{github.workspace}}/scripts/install-ubuntu.sh
+                run: cd ~ && sudo chmod +x ${{github.workspace}}/scripts/install-ubuntu.sh && ${{github.workspace}}/scripts/install-ubuntu.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,9 @@
+name: ci
+on: [push]
+jobs:
+    run-ci:
+        runs-on: ubuntu-latest
+        steps:
+            - 
+                name: setup-env
+                run: ./scripts/install-ubuntu.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,7 @@ jobs:
                 name: test
                 run: |
                     cd ${{github.workspace}}
+                    cd build
                     ./bin/LepusUtility_Tests
                     ./bin/LepusSystem_Tests
                     ./bin/Lepus3D_Tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ jobs:
     run-ci:
         runs-on: ubuntu-latest
         steps:
+            - uses: actions/checkout@v3
             - 
                 name: setup-env
-                run: cd ~ && ls ${{github.workspace}} && ${{github.workspace}}/scripts/install-ubuntu.sh
+                run: cd ~ && ${{github.workspace}}/scripts/install-ubuntu.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,28 @@
 name: ci
 on: [push]
 jobs:
-    run-ci:
+    run-ci-linux:
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v3
             - 
                 name: setup-env
-                run: cd ~ && sudo chmod +x ${{github.workspace}}/scripts/install-ubuntu.sh && ${{github.workspace}}/scripts/install-ubuntu.sh
+                run: |
+                    cd ~ 
+                    sudo chmod +x ${{github.workspace}}/scripts/install-ubuntu.sh 
+                    ${{github.workspace}}/scripts/install-ubuntu.sh
+            - 
+                name: build
+                run: |
+                    cd ${{github.workspace}}
+                    mkdir build
+                    cmake -B ./build -S ./ -G "Unix Makefiles" --toolchain ~/vcpkg/scripts/buildsystems/vcpkg.cmake
+                    cd build
+                    make
+            - 
+                name: test
+                run: |
+                    cd ${{github.workspace}}
+                    ./bin/LepusUtility_Tests
+                    ./bin/LepusSystem_Tests
+                    ./bin/Lepus3D_Tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,8 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v3
+              with: 
+                submodules: true
             - 
                 name: setup-env
                 run: |

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,9 +5,22 @@
     "version": "0.2.0",
     "configurations": [
         {
-            "name": "LepusDemo Debug",
+            "name": "LepusDemo Debug (Linux)",
             "program": "${workspaceRoot}/build/bin/LepusDemo",
+            "windows": {
+                // Use the Windows variant instead.
+                "program": ""
+            },
             "type": "cppdbg",
+            "request": "launch",
+            "cwd": "${workspaceRoot}/build/bin/Debug"
+        },
+        {
+            "name": "LepusDemo Debug (Windows)",
+            "type": "cppvsdbg",
+            "windows": {
+                "program": "${workspaceRoot}/build/bin/Debug/LepusDemo.exe"
+            },
             "request": "launch",
             "cwd": "${workspaceRoot}/build/bin/Debug"
         }

--- a/scripts/install-ubuntu.sh
+++ b/scripts/install-ubuntu.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+# APT update
+echo "Updating APT index"
+sudo apt update
+
+# GNU build tools
+echo "Installing GNU Make and GCC"
+sudo apt install make gcc
+
+# Git
+echo "Instaling Git"
+sudo apt install git
+
+# OpenGL
+echo "Installing OpenGL and Xorg dependencies"
+sudo apt install libopengl-dev libgl-dev libgl1-mesa-dev libgl1-mesa-glx libxinerama-dev libxcursor-dev xorg-dev libglu1-mesa-dev
+
+# VCPKG
+echo "Installing vcpkg"
+git clone https://github.com/microsoft/vcpkg
+./vcpkg/bootstrap-vcpkg.sh
+
+# CMake
+echo "Installing CMake"
+wget https://github.com/Kitware/CMake/releases/download/v3.27.0/cmake-3.27.0-linux-x86_64.sh
+sudo chmod +x ./cmake-3.27.0-linux-x86_64.sh
+mkdir cmake3.27.0
+sudo ./cmake-3.27.0-linux-x86_64.sh --prefix=cmake3.27.0 --skip-license
+ln -s ./cmake3.27.0/bin/cmake ~/

--- a/src/LDemo/main.cpp
+++ b/src/LDemo/main.cpp
@@ -28,7 +28,7 @@ using namespace LepusEngine;
 int main()
 {
 	// Enable logging
-	LepusEngine::ConsoleLogger.Enabled = true;
+	LepusEngine::ConsoleLogger::Global().Enabled = true;
 
 	std::shared_ptr<LepusEngine::LepusSystem::WindowingGLFW> windowing = std::make_shared<LepusSystem::WindowingGLFW>(800, 600);
 
@@ -44,7 +44,7 @@ int main()
 	windowing->SetAsCurrentContext();
 
 	// Output start message to console
-	LepusEngine::ConsoleLogger.LogInfo("", "main", "Demo starting!");
+	LepusEngine::ConsoleLogger::Global().LogInfo("", "main", "Demo starting!");
 
 	// Load & compile shaders.
 	std::string vertShaderSrc = LepusSystem::FileSystem::Read("../../Content/GLSL/Unlit/RGBVertex.vert"), fragShaderSrc = LepusSystem::FileSystem::Read("../../Content/GLSL/Unlit/RGBVertex.frag");
@@ -67,11 +67,13 @@ int main()
 	}
 
 	// Output shutdown message to console
-	LepusEngine::ConsoleLogger.LogInfo("", "main", "Demo shutting down!");
+	LepusEngine::ConsoleLogger::Global().LogInfo("", "main", "Demo shutting down!");
 
 	windowing->Shutdown();
 
 	LepusEngine::LepusSystem::WindowingGLFW::Terminate();
+
+	LepusEngine::ConsoleLogger::Shutdown();
 
 	return 0;
 }

--- a/src/LEngine/ConsoleLogger.h
+++ b/src/LEngine/ConsoleLogger.h
@@ -1,19 +1,34 @@
-#pragma once
+#ifndef LENGINE_CONSOLE_LOGGER_INSTANCE
+#define LENGINE_CONSOLE_LOGGER_INSTANCE
 
 #include "ILogger.h"
 
-namespace LepusEngine 
+namespace LepusEngine
 {
 	// An stdout-based ILogger implementation.
 	// LEPUS_ALLOW_STDOUT needs to be defined and LepusEngine::ConsoleLogger::Enabled needs to be true for the logs to appear.
-	class ConsoleLoggerImpl : ILogger {
-	private:
+	class ConsoleLogger : ILogger
+	{
+		private:
 		void LogInternal(char* className, char* funcName, int eventType, char* message, char* funcParams);
-	public:
+		static ILogger* m_Instance;
+
+		public:
 		bool Enabled;
 
-		ConsoleLoggerImpl() {
+		ConsoleLogger()
+		{
 			Enabled = false;
+		}
+
+		static ConsoleLogger& Global()
+		{
+			if (!m_Instance)
+			{
+				m_Instance = new ConsoleLogger();
+			}
+
+			return *reinterpret_cast<ConsoleLogger*>(m_Instance);
 		}
 
 		inline void Log(char* className, char* funcName, int eventType, char* message, char* funcParams)
@@ -26,7 +41,15 @@ namespace LepusEngine
 		void LogError(char* className, char* funcName, char* message, char* funcParams = "") { Log(className, funcName, LogEventTypes::LEPUS_ERROR, message, funcParams); }
 		void LogInfo(char* className, char* funcName, char* message, char* funcParams = "") { Log(className, funcName, LogEventTypes::LEPUS_INFO, message, funcParams); }
 		void LogWarning(char* className, char* funcName, char* message, char* funcParams = "") { Log(className, funcName, LogEventTypes::LEPUS_WARNING, message, funcParams); }
-	};
 
-	ConsoleLoggerImpl ConsoleLogger;
+		static void Shutdown()
+		{
+			if (m_Instance)
+			{
+				delete m_Instance;
+				m_Instance = nullptr;
+			}
+		}
+	};
 }
+#endif

--- a/src/LEngine/Logger/ConsoleLogger.cpp
+++ b/src/LEngine/Logger/ConsoleLogger.cpp
@@ -5,7 +5,9 @@
 using namespace LepusEngine;
 using namespace std;
 
-void ConsoleLoggerImpl::LogInternal(char* cN, char* fN, int eT, char* msg, char* fP)
+ILogger* ConsoleLogger::m_Instance = nullptr;
+
+void ConsoleLogger::LogInternal(char* cN, char* fN, int eT, char* msg, char* fP)
 {
 	if (Enabled)
 	{
@@ -19,19 +21,19 @@ void ConsoleLoggerImpl::LogInternal(char* cN, char* fN, int eT, char* msg, char*
 
 		switch (eT)
 		{
-		case LogEventTypes::LEPUS_ERROR:
-			output.append("error");
-			break;
-		case LogEventTypes::LEPUS_INFO:
-			output.append("info");
-			break;
-		case LogEventTypes::LEPUS_WARNING:
-			output.append("warning");
-			break;
-		default:
-			output.append("unknown, type ");
-			output.append(to_string(eT));
-			break;
+			case LogEventTypes::LEPUS_ERROR:
+				output.append("error");
+				break;
+			case LogEventTypes::LEPUS_INFO:
+				output.append("info");
+				break;
+			case LogEventTypes::LEPUS_WARNING:
+				output.append("warning");
+				break;
+			default:
+				output.append("unknown, type ");
+				output.append(to_string(eT));
+				break;
 		}
 
 		output.append("): ");

--- a/src/LEngine/Physics/PhysicsRigidbody.cpp
+++ b/src/LEngine/Physics/PhysicsRigidbody.cpp
@@ -1,5 +1,4 @@
 #include "PhysicsRigidbody.h"
-#include <LEngine/ConsoleLogger.h>
 //#include <L3D/Vertex.h>
 //#include <L3D/Transform.h>
 #include <algorithm>
@@ -11,10 +10,10 @@ using namespace LepusEngine;
 PhysicsRigidbody::PhysicsRigidbody()
 {
 	// Initialise material, geometry and rigidbody 
-	m_Active = false; 
-	m_PhysicsEngine = nullptr; 
-	mBtCollider = nullptr; 
-	mBtRigidbody = nullptr; 
+	m_Active = false;
+	m_PhysicsEngine = nullptr;
+	mBtCollider = nullptr;
+	mBtRigidbody = nullptr;
 	mBtMotionState = nullptr;
 }
 
@@ -22,7 +21,7 @@ PhysicsRigidbody::PhysicsRigidbody(Physics& physicsEngine, Lepus3D::Geometry* ge
 {
 	m_PhysicsEngine = &physicsEngine;
 
-    InitCollider(physicsEngine, geometry, transform);
+	InitCollider(physicsEngine, geometry, transform);
 	//m_PxMat = physicsEngine.m_API->m_PxPhysics->createMaterial(0.5f, 0.5f, 0.6f); // TODO: these are only test parameters - change them, or provide a way to override.
 	//TODO: Lepus3D::Vector3 position = transform.GetPosition();
 	//TODO: Lepus3D::Quaternion rot = transform.GetRotation();
@@ -51,7 +50,7 @@ void PhysicsRigidbody::InitCollider(Physics& physicsEngine, Lepus3D::Geometry* g
 	// TODO
 	/*desc.points.data = pointsData;
 	desc.points.stride = sizeof(float) * 3;
-	
+
 	desc.flags = physx::PxConvexFlag::eCOMPUTE_CONVEX;
 	physicsEngine.m_API->m_PxCooking->cookConvexMesh(desc, outStream);
 
@@ -128,5 +127,5 @@ btRigidBody* const LepusEngine::PhysicsRigidbody::GetBtRigidbody()
 */
 LepusEngine::PhysicsRigidbody::~PhysicsRigidbody()
 {
-	
+
 }


### PR DESCRIPTION
This PR adds a CI workflow for testing a Linux build of the engine.

The `scripts/install-ubuntu.sh` script contains bash commands to install all the tools and dependencies required to build the engine in an Ubuntu Linux environment.

The CI is contained within a single job as the workspace would ideally have to be shared between the jobs, which is not possible on GitHub-hosted runners, so instead I'm treating steps as jobs here.