### PR TITLE
refactor: added lepus::engine::objects::Mesh and lepus::gfx::GLMesh

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,9 +70,9 @@ include_directories(${CMAKE_SOURCE_DIR}/3rdparty/imgui)
 add_executable(LepusDemo src/examples/demo/DemoApp.h src/examples/demo/main.cpp)
 
 # LepusUtility
-file(GLOB_RECURSE LEPUSUTILITY_HEADERS ${LEPUS_SRC_DIR}/utility/*.h ${LEPUS_SRC_DIR}/utility/**/*.h)
-add_custom_target(LepusUtility SOURCES ${LEPUSUTILITY_HEADERS})
-source_group(TREE ${LEPUS_SRC_DIR}/utility FILES ${LEPUSUTILITY_HEADERS})
+# file(GLOB_RECURSE LEPUSUTILITY_HEADERS ${LEPUS_SRC_DIR}/utility/*.h ${LEPUS_SRC_DIR}/utility/**/*.h)
+# add_custom_target(LepusUtility SOURCES ${LEPUSUTILITY_HEADERS})
+# source_group(TREE ${LEPUS_SRC_DIR}/utility FILES ${LEPUSUTILITY_HEADERS})
 
 # LepusGfx shaders
 file(GLOB LEPUS3D_SHADERS_SRC ${CMAKE_SOURCE_DIR}/Content/GLSL/*.frag ${CMAKE_SOURCE_DIR}/Content/GLSL/*.vert)
@@ -90,7 +90,12 @@ file(GLOB_RECURSE LepusEngine_SRC ${LEPUS_SRC_DIR}/engine/*.h ${LEPUS_SRC_DIR}/e
 add_library(LepusEngine ${LepusEngine_SRC})
 source_group(TREE ${LEPUS_SRC_DIR}/engine FILES ${LepusEngine_SRC})
 
-# LepusSystem sources
+# LepusUtility sources
+file(GLOB_RECURSE LepusUtility_SRC ${LEPUS_SRC_DIR}/utility/*.h ${LEPUS_SRC_DIR}/utility/*.cpp ${LEPUS_SRC_DIR}/utility/**/*.h ${LEPUS_SRC_DIR}/utility/**/*.cpp)
+add_library(LepusUtility ${LepusUtility_SRC})
+source_group(TREE ${LEPUS_SRC_DIR}/utility FILES ${LepusUtility_SRC})
+
+# LepusUtility sources
 file(GLOB_RECURSE LepusSystem_SRC ${LEPUS_SRC_DIR}/system/*.h ${LEPUS_SRC_DIR}/system/*.cpp ${LEPUS_SRC_DIR}/system/**/*.h ${LEPUS_SRC_DIR}/system/**/*.cpp)
 add_library(LepusSystem ${LepusSystem_SRC})
 source_group(TREE ${LEPUS_SRC_DIR}/system FILES ${LepusSystem_SRC})
@@ -155,8 +160,8 @@ if(OpenGL::GL)
 elseif(OpenGL::OpenGL)
 	set(GL_LIBRARY OpenGL::OpenGL)
 endif(OpenGL::GL)
-target_link_libraries(LepusGfx PRIVATE GL3W glfw ${GL_LIBRARY} DearImgui LepusEngine LepusSystem)
-target_link_libraries(LepusDemo PRIVATE DearImgui LepusGfx LepusEngine)
+target_link_libraries(LepusGfx PRIVATE GL3W glfw ${GL_LIBRARY} DearImgui LepusEngine LepusUtility LepusSystem)
+target_link_libraries(LepusDemo PRIVATE DearImgui LepusGfx LepusUtility LepusEngine)
 
 # Copy content (models, GLSL, etc.)
 file(MAKE_DIRECTORY ${CMAKE_BINARY_DIR}/Content)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,7 +95,7 @@ file(GLOB_RECURSE LepusUtility_SRC ${LEPUS_SRC_DIR}/utility/*.h ${LEPUS_SRC_DIR}
 add_library(LepusUtility ${LepusUtility_SRC})
 source_group(TREE ${LEPUS_SRC_DIR}/utility FILES ${LepusUtility_SRC})
 
-# LepusUtility sources
+# LepusSystem sources
 file(GLOB_RECURSE LepusSystem_SRC ${LEPUS_SRC_DIR}/system/*.h ${LEPUS_SRC_DIR}/system/*.cpp ${LEPUS_SRC_DIR}/system/**/*.h ${LEPUS_SRC_DIR}/system/**/*.cpp)
 add_library(LepusSystem ${LepusSystem_SRC})
 source_group(TREE ${LEPUS_SRC_DIR}/system FILES ${LepusSystem_SRC})

--- a/src/lepus/engine/Objects/Mesh.h
+++ b/src/lepus/engine/Objects/Mesh.h
@@ -42,7 +42,7 @@ namespace lepus
                 public:
 #define LEPUS_MESH_CONSTRUCTOR(MeshClass) \
                 inline MeshClass(lepus::engine::MeshVertexFormat format = lepus::engine::MeshVertexFormat::VVV) {Init(format);} \
-                inline MeshClass(lepus::utility::Primitive& primitive, bool copy = false) {Init((void*)primitive.GetVertices(), primitive.VertexBufferSize(), lepus::engine::MeshVertexFormat::VVV, (uint32_t*)primitive.GetIndices(), primitive.IndexCount(), copy);} \
+                inline MeshClass(const lepus::utility::Primitive& primitive, bool copy = false) {Init((void*)primitive.GetVertices(), primitive.VertexBufferSize(), lepus::engine::MeshVertexFormat::VVV, (uint32_t*)primitive.GetIndices(), primitive.IndexCount(), copy);} \
                 inline MeshClass(void* vertices, size_t szVertices, lepus::engine::MeshVertexFormat format = lepus::engine::MeshVertexFormat::VVV, uint32_t* indices = nullptr, size_t indexCount = 0, bool copy = false) {Init(vertices, szVertices, format, indices, indexCount, copy);} \
                 inline virtual ~MeshClass() {Dispose();}
 
@@ -56,7 +56,7 @@ namespace lepus
                     InitInternal();
                 }
 
-                inline void Init(lepus::utility::Primitive& primitive, bool copy = false)
+                inline void Init(const lepus::utility::Primitive& primitive, bool copy = false)
                 {
                     Init((void*)primitive.GetVertices(), primitive.VertexBufferSize(), MeshVertexFormat::VVV, (uint32_t*)primitive.GetIndices(), primitive.IndexCount(), copy);
                 }

--- a/src/lepus/engine/Objects/Mesh.h
+++ b/src/lepus/engine/Objects/Mesh.h
@@ -48,6 +48,48 @@ namespace lepus
 
                 LEPUS_MESH_CONSTRUCTOR(Mesh);
 
+                Mesh(Mesh& other)
+                {
+                    m_Format = MeshVertexFormat::Invalid;
+                    m_Vertices = nullptr;
+                    m_szVertices = 0;
+                    m_OwnData = false;
+                    m_Indices = nullptr;
+                    m_IndexCount = 0;
+                    m_IsIndexed = false;
+
+                    *this = std::move(other);
+                }
+
+                Mesh& operator=(Mesh&& other)
+                {
+                    if (this != &other)
+                    {
+                        Dispose();
+
+                        m_Format = other.m_Format;
+
+                        m_Vertices = other.m_Vertices;
+                        m_szVertices = other.m_szVertices;
+
+                        m_Indices = other.m_Indices;
+                        m_IndexCount = other.m_IndexCount;
+
+                        m_IsIndexed = other.m_IsIndexed;
+                        m_OwnData = other.m_OwnData;
+
+                        other.m_Format = MeshVertexFormat::Invalid;
+                        other.m_IndexCount = 0;
+                        other.m_szVertices = 0;
+                        other.m_Indices = nullptr;
+                        other.m_Vertices = nullptr;
+                        other.m_OwnData = false;
+                        other.m_IsIndexed = false;
+                    }
+
+                    return *this;
+                }
+
                 inline void Init(MeshVertexFormat format = MeshVertexFormat::VVV)
                 {
                     m_Format = format;
@@ -99,17 +141,17 @@ namespace lepus
 
                 inline MeshVertexFormat GetFormat() const { return m_Format; }
 
-                const void* GetVertices()
+                const void* GetVertices() const
                 {
                     return m_Vertices;
                 }
 
-                const uint32_t* GetIndices()
+                const uint32_t* GetIndices() const
                 {
                     return m_Indices;
                 }
 
-                const uint8_t GetSingleVertexSize()
+                uint8_t GetSingleVertexSize() const
                 {
                     switch (m_Format)
                     {
@@ -121,22 +163,22 @@ namespace lepus
                     }
                 }
 
-                const size_t inline VertexCount()
+                size_t inline VertexCount() const
                 {
                     return m_szVertices / GetSingleVertexSize();
                 }
 
-                constexpr size_t const inline VertexBufferSize()
+                size_t inline VertexBufferSize() const
                 {
                     return m_szVertices;
                 }
 
-                constexpr size_t const inline IndexBufferSize()
+                size_t inline IndexBufferSize() const
                 {
                     return m_IndexCount * sizeof(uint32_t);
                 }
 
-                const size_t inline IndexCount()
+                size_t inline IndexCount() const
                 {
                     return m_IndexCount;
                 }
@@ -148,11 +190,15 @@ namespace lepus
                         if (m_Vertices)
                         {
                             free(m_Vertices);
+                            m_Vertices = nullptr;
+                            m_szVertices = 0;
                         }
 
                         if (m_Indices)
                         {
                             delete[] m_Indices;
+                            m_Indices = nullptr;
+                            m_IndexCount = 0;
                         }
                     }
                 }

--- a/src/lepus/engine/Objects/Mesh.h
+++ b/src/lepus/engine/Objects/Mesh.h
@@ -63,6 +63,28 @@ namespace lepus
 
                 }
 
+                inline void MoveInternal(Mesh& other)
+                {
+                    m_Format = other.m_Format;
+
+                    m_Vertices = other.m_Vertices;
+                    m_szVertices = other.m_szVertices;
+
+                    m_Indices = other.m_Indices;
+                    m_IndexCount = other.m_IndexCount;
+
+                    m_IsIndexed = other.m_IsIndexed;
+                    m_OwnData = other.m_OwnData;
+
+                    other.m_Format = MeshVertexFormat::Invalid;
+                    other.m_IndexCount = 0;
+                    other.m_szVertices = 0;
+                    other.m_Indices = nullptr;
+                    other.m_Vertices = nullptr;
+                    other.m_OwnData = false;
+                    other.m_IsIndexed = false;
+                }
+
 #define LEPUS_MESH_CONSTRUCTOR(MeshClass) \
                 public:\
                 inline MeshClass(lepus::engine::MeshVertexFormat format = lepus::engine::MeshVertexFormat::VVV) {Init(format);} \
@@ -116,24 +138,7 @@ namespace lepus
                         // Make sure our data is disposed first if necessary so memory doesn't leak.
                         Dispose();
 
-                        m_Format = other.m_Format;
-
-                        m_Vertices = other.m_Vertices;
-                        m_szVertices = other.m_szVertices;
-
-                        m_Indices = other.m_Indices;
-                        m_IndexCount = other.m_IndexCount;
-
-                        m_IsIndexed = other.m_IsIndexed;
-                        m_OwnData = other.m_OwnData;
-
-                        other.m_Format = MeshVertexFormat::Invalid;
-                        other.m_IndexCount = 0;
-                        other.m_szVertices = 0;
-                        other.m_Indices = nullptr;
-                        other.m_Vertices = nullptr;
-                        other.m_OwnData = false;
-                        other.m_IsIndexed = false;
+                        MoveInternal(other);
                     }
 
                     return *this;

--- a/src/lepus/engine/Objects/Mesh.h
+++ b/src/lepus/engine/Objects/Mesh.h
@@ -38,6 +38,8 @@ namespace lepus
 
                 /// @brief Does this Mesh own the vertex/index data? If true, this Mesh will delete the data when Dispose is called.
                 bool m_OwnData = false;
+
+                /// @brief Is the Mesh indexed?
                 bool m_IsIndexed = false;
 
                 protected:

--- a/src/lepus/engine/Objects/Mesh.h
+++ b/src/lepus/engine/Objects/Mesh.h
@@ -19,17 +19,24 @@ namespace lepus
 
         namespace objects
         {
+            /// @brief Base class for Mesh data in the engine.
+            ///
+            /// Can be specialised for different parts of the engine (e.g.rendering, physics) by inheriting and adding API-specific logic as needed.
             class Mesh
             {
                 private:
+                /// @brief The vertex format used by the mesh data.
                 MeshVertexFormat m_Format = MeshVertexFormat::Invalid;
 
+                /// @brief Vertex data
                 void* m_Vertices = nullptr;
                 size_t m_szVertices = 0;
 
+                /// @brief Index data (optional, but common enough to be included in the base class for simplicity's sake)
                 uint32_t* m_Indices = nullptr;
                 size_t m_IndexCount = 0;
 
+                /// @brief Does this Mesh own the vertex/index data? If true, this Mesh will delete the data when Dispose is called.
                 bool m_OwnData = false;
                 bool m_IsIndexed = false;
 
@@ -48,6 +55,7 @@ namespace lepus
                     m_OwnData = false;
                 }
 
+                /// @brief Always called after constructing a new Mesh instance (excluding move/copy ctors).
                 inline virtual void InitInternal()
                 {
 
@@ -94,12 +102,14 @@ namespace lepus
                 }
 
                 /// @brief Move assignment
-                /// @param other Rvalue to assign
+                /// @param other Mesh rvalue to assign
                 /// @return The current object with vertices, indices and any metadata from the rvalue. 
                 Mesh& operator=(Mesh&& other)
                 {
+                    // Prevent self-assignment.
                     if (this != &other)
                     {
+                        // Make sure our data is disposed first if necessary so memory doesn't leak.
                         Dispose();
 
                         m_Format = other.m_Format;
@@ -125,19 +135,36 @@ namespace lepus
                     return *this;
                 }
 
+                /// @brief Default constructor. Initialises an empty mesh with just a vertex format and no vertices.
+                /// @param format Vertex format to use.
                 inline void Init(MeshVertexFormat format = MeshVertexFormat::VVV)
                 {
                     m_Format = format;
-                    m_OwnData = true;
+                    m_OwnData = false;
+                    m_IsIndexed = false;
+                    m_szVertices = 0;
+                    m_IndexCount = 0;
+                    m_Vertices = nullptr;
+                    m_Indices = nullptr;
 
                     InitInternal();
                 }
 
+                /// @brief Initialises the Mesh with geometry data from a built-in primitive.
+                /// @param primitive A built-in primitive instance from LepusUtility.
+                /// @param copy Should the data be copied?
                 inline void Init(const lepus::utility::Primitive& primitive, bool copy = false)
                 {
                     Init((void*)primitive.GetVertices(), primitive.VertexBufferSize(), MeshVertexFormat::VVV, (uint32_t*)primitive.GetIndices(), primitive.IndexCount(), copy);
                 }
 
+                /// @brief Initialises the Mesh with provided geometry data.
+                /// @param vertices Vertex data
+                /// @param szVertices Size of the vertex data (in bytes)
+                /// @param format Vertex data format
+                /// @param indices Index data. Optional - pass nullptr for non-indexed.
+                /// @param indexCount Number of indices.
+                /// @param copy Should the data be copied?
                 inline void Init(void* vertices, size_t szVertices, MeshVertexFormat format = MeshVertexFormat::VVV, uint32_t* indices = nullptr, size_t indexCount = 0, bool copy = false)
                 {
                     m_Format = format;
@@ -174,18 +201,26 @@ namespace lepus
                     InitInternal();
                 }
 
+                /// @brief Gets the vertex format used by this Mesh.
+                /// @return The MeshVertexFormat this Mesh was initialised with.
                 inline MeshVertexFormat GetFormat() const { return m_Format; }
 
+                /// @brief Gets the pointer to vertex data used by this Mesh.
+                /// @return A constant pointer to the vertex data.
                 const void* GetVertices() const
                 {
                     return m_Vertices;
                 }
 
+                /// @brief Gets the pointer to index data used by this Mesh.
+                /// @return A constant pointer to the index data.
                 const uint32_t* GetIndices() const
                 {
                     return m_Indices;
                 }
 
+                /// @brief Gets the size of a single vertex based on the vertex format used by this Mesh.
+                /// @return An unsigned 8-bit integer defining a single vertex size.
                 uint8_t GetSingleVertexSize() const
                 {
                     switch (m_Format)
@@ -198,26 +233,35 @@ namespace lepus
                     }
                 }
 
+                /// @brief Gets the number of vertices in this Mesh.
+                /// @return An unsigned 64-bit integer defining the number of vertices (TODO: that's a maximum of 18,446,744,073,709,551,615 vertices... do we really need 64-bit for that?)
                 size_t inline VertexCount() const
                 {
                     return m_szVertices / GetSingleVertexSize();
                 }
 
+                /// @brief Gets the size of the vertex data.
+                /// @return An unsigned 64-bit integer defining the size of the vertex data (in bytes).
                 size_t inline VertexBufferSize() const
                 {
                     return m_szVertices;
                 }
 
+                /// @brief Gets the size of the index data.
+                /// @return An unsigned 64-bit integer defining the size of the index data (in bytes).
                 size_t inline IndexBufferSize() const
                 {
                     return m_IndexCount * sizeof(uint32_t);
                 }
 
+                /// @brief Gets the number of indices in this Mesh.
+                /// @return An unsigned 64-bit integer defining the number of indices that make up this Mesh (TODO: again, isn't 64 bits overkill?)
                 size_t inline IndexCount() const
                 {
                     return m_IndexCount;
                 }
 
+                /// @brief Releases any resources and data held by this Mesh as needed.
                 inline virtual void Dispose()
                 {
                     if (m_OwnData)
@@ -239,9 +283,7 @@ namespace lepus
                 }
             };
         }
-    } // namespace engine
-
-} // namespace lepus
-
+    }
+}
 
 #endif

--- a/src/lepus/engine/Objects/Mesh.h
+++ b/src/lepus/engine/Objects/Mesh.h
@@ -34,6 +34,20 @@ namespace lepus
                 bool m_IsIndexed = false;
 
                 protected:
+                inline void CopyInternal(const Mesh& other)
+                {
+                    m_Format = other.m_Format;
+                    m_Vertices = other.m_Vertices;
+                    m_szVertices = other.m_szVertices;
+                    m_IndexCount = other.m_IndexCount;
+                    m_Indices = other.m_Indices;
+                    m_IsIndexed = other.m_IsIndexed;
+
+                    // We're not making a copy of the data, so we don't own it.
+                    // TODO: Add some kind of reference counting via a resource manager, so if we copy an existing mesh, its data doesn't get disposed until its copies are.
+                    m_OwnData = false;
+                }
+
                 inline virtual void InitInternal()
                 {
 
@@ -48,7 +62,25 @@ namespace lepus
 
                 LEPUS_MESH_CONSTRUCTOR(Mesh);
 
-                Mesh(Mesh& other)
+                /// @brief Copy constructor
+                /// @param other Mesh object to copy
+                Mesh(const Mesh& other)
+                {
+                    CopyInternal(other);
+                }
+
+                /// @brief Copy assignment
+                /// @param other Mesh object to copy
+                /// @return
+                Mesh& operator=(const Mesh& other)
+                {
+                    CopyInternal(other);
+                    return *this;
+                }
+
+                /// @brief Move constructor
+                /// @param other Rvalue to initialise the Mesh object with.
+                Mesh(Mesh&& other)
                 {
                     m_Format = MeshVertexFormat::Invalid;
                     m_Vertices = nullptr;
@@ -61,6 +93,9 @@ namespace lepus
                     *this = std::move(other);
                 }
 
+                /// @brief Move assignment
+                /// @param other Rvalue to assign
+                /// @return The current object with vertices, indices and any metadata from the rvalue. 
                 Mesh& operator=(Mesh&& other)
                 {
                     if (this != &other)
@@ -183,7 +218,7 @@ namespace lepus
                     return m_IndexCount;
                 }
 
-                inline void Dispose()
+                inline virtual void Dispose()
                 {
                     if (m_OwnData)
                     {

--- a/src/lepus/engine/Objects/Mesh.h
+++ b/src/lepus/engine/Objects/Mesh.h
@@ -63,14 +63,16 @@ namespace lepus
 
                 }
 
-                public:
 #define LEPUS_MESH_CONSTRUCTOR(MeshClass) \
+                public:\
                 inline MeshClass(lepus::engine::MeshVertexFormat format = lepus::engine::MeshVertexFormat::VVV) {Init(format);} \
                 inline MeshClass(const lepus::utility::Primitive& primitive, bool copy = false) {Init((void*)primitive.GetVertices(), primitive.VertexBufferSize(), lepus::engine::MeshVertexFormat::VVV, (uint32_t*)primitive.GetIndices(), primitive.IndexCount(), copy);} \
                 inline MeshClass(void* vertices, size_t szVertices, lepus::engine::MeshVertexFormat format = lepus::engine::MeshVertexFormat::VVV, uint32_t* indices = nullptr, size_t indexCount = 0, bool copy = false) {Init(vertices, szVertices, format, indices, indexCount, copy);} \
                 inline virtual ~MeshClass() {Dispose();}
 
                 LEPUS_MESH_CONSTRUCTOR(Mesh);
+
+                public:
 
                 /// @brief Copy constructor
                 /// @param other Mesh object to copy

--- a/src/lepus/engine/Objects/Mesh.h
+++ b/src/lepus/engine/Objects/Mesh.h
@@ -1,0 +1,166 @@
+#ifndef LEPUS_ENGINE_OBJECTS_MESH
+#define LEPUS_ENGINE_OBJECTS_MESH
+
+#include <cstdlib>
+#include <memory>
+#include <lepus/utility/Primitives.h>
+
+namespace lepus
+{
+    namespace engine
+    {
+        /// @brief Different vertex formats supported by the engine.
+        enum MeshVertexFormat
+        {
+            /// @brief (Default) 3 positional components (XYZ) for each vertex
+            VVV,
+            Invalid
+        };
+
+        namespace objects
+        {
+            class Mesh
+            {
+                private:
+                MeshVertexFormat m_Format = MeshVertexFormat::Invalid;
+
+                void* m_Vertices = nullptr;
+                size_t m_szVertices = 0;
+
+                uint32_t* m_Indices = nullptr;
+                size_t m_IndexCount = 0;
+
+                bool m_OwnData = false;
+                bool m_IsIndexed = false;
+
+                protected:
+                inline virtual void InitInternal()
+                {
+
+                }
+
+                public:
+#define LEPUS_MESH_CONSTRUCTOR(MeshClass) \
+                inline MeshClass(lepus::engine::MeshVertexFormat format = lepus::engine::MeshVertexFormat::VVV) {Init(format);} \
+                inline MeshClass(lepus::utility::Primitive& primitive, bool copy = false) {Init((void*)primitive.GetVertices(), primitive.VertexBufferSize(), lepus::engine::MeshVertexFormat::VVV, (uint32_t*)primitive.GetIndices(), primitive.IndexCount(), copy);} \
+                inline MeshClass(void* vertices, size_t szVertices, lepus::engine::MeshVertexFormat format = lepus::engine::MeshVertexFormat::VVV, uint32_t* indices = nullptr, size_t indexCount = 0, bool copy = false) {Init(vertices, szVertices, format, indices, indexCount, copy);} \
+                inline virtual ~MeshClass() {Dispose();}
+
+                LEPUS_MESH_CONSTRUCTOR(Mesh);
+
+                inline void Init(MeshVertexFormat format = MeshVertexFormat::VVV)
+                {
+                    m_Format = format;
+                    m_OwnData = true;
+
+                    InitInternal();
+                }
+
+                inline void Init(lepus::utility::Primitive& primitive, bool copy = false)
+                {
+                    Init((void*)primitive.GetVertices(), primitive.VertexBufferSize(), MeshVertexFormat::VVV, (uint32_t*)primitive.GetIndices(), primitive.IndexCount(), copy);
+                }
+
+                inline void Init(void* vertices, size_t szVertices, MeshVertexFormat format = MeshVertexFormat::VVV, uint32_t* indices = nullptr, size_t indexCount = 0, bool copy = false)
+                {
+                    m_Format = format;
+                    m_IsIndexed = indexCount > 0 && indices != nullptr;
+                    m_szVertices = szVertices;
+
+                    if (copy)
+                    {
+                        m_Vertices = malloc(szVertices);
+                        memcpy(m_Vertices, vertices, szVertices);
+
+                        if (m_IsIndexed)
+                        {
+                            m_IndexCount = indexCount;
+                            m_Indices = new uint32_t[indexCount];
+                            memcpy(m_Indices, indices, indexCount * sizeof(uint32_t));
+                        }
+
+                        m_OwnData = true;
+                    }
+                    else
+                    {
+                        m_Vertices = vertices;
+
+                        if (m_IsIndexed)
+                        {
+                            m_IndexCount = indexCount;
+                            m_Indices = indices;
+                        }
+
+                        m_OwnData = false;
+                    }
+
+                    InitInternal();
+                }
+
+                inline MeshVertexFormat GetFormat() const { return m_Format; }
+
+                const void* GetVertices()
+                {
+                    return m_Vertices;
+                }
+
+                const uint32_t* GetIndices()
+                {
+                    return m_Indices;
+                }
+
+                const uint8_t GetSingleVertexSize()
+                {
+                    switch (m_Format)
+                    {
+                        case MeshVertexFormat::VVV:
+                            return sizeof(float) * 3;
+                        case MeshVertexFormat::Invalid:
+                        default:
+                            return 0;
+                    }
+                }
+
+                const size_t inline VertexCount()
+                {
+                    return m_szVertices / GetSingleVertexSize();
+                }
+
+                constexpr size_t const inline VertexBufferSize()
+                {
+                    return m_szVertices;
+                }
+
+                constexpr size_t const inline IndexBufferSize()
+                {
+                    return m_IndexCount * sizeof(uint32_t);
+                }
+
+                const size_t inline IndexCount()
+                {
+                    return m_IndexCount;
+                }
+
+                inline void Dispose()
+                {
+                    if (m_OwnData)
+                    {
+                        if (m_Vertices)
+                        {
+                            free(m_Vertices);
+                        }
+
+                        if (m_Indices)
+                        {
+                            delete[] m_Indices;
+                        }
+                    }
+                }
+            };
+        }
+    } // namespace engine
+
+} // namespace lepus
+
+
+#endif

--- a/src/lepus/gfx/GraphicsEngine/Apis/ApiGL.h
+++ b/src/lepus/gfx/GraphicsEngine/Apis/ApiGL.h
@@ -87,7 +87,7 @@ namespace lepus
 			GLuint m_Programs[GraphicsApiGLOptions::ProgramCount];
 
 			// TODO: separate
-			LepusUtility::Primitive m_CubeGeometry = LepusUtility::Primitives::Cube();
+			const lepus::utility::Primitive& m_CubeGeometry = lepus::utility::Primitives::Cube();
 
 			private:
 			void SetupVertexArrays();

--- a/src/lepus/gfx/GraphicsEngine/Apis/ApiGL.h
+++ b/src/lepus/gfx/GraphicsEngine/Apis/ApiGL.h
@@ -86,9 +86,6 @@ namespace lepus
 
 			GLuint m_Programs[GraphicsApiGLOptions::ProgramCount];
 
-			// TODO: separate
-			const lepus::utility::Primitive& m_CubeGeometry = lepus::utility::Primitives::Cube();
-
 			private:
 			void SetupVertexArrays();
 			void SetupBuffers();

--- a/src/lepus/gfx/GraphicsEngine/Apis/ApiGL.h
+++ b/src/lepus/gfx/GraphicsEngine/Apis/ApiGL.h
@@ -9,6 +9,7 @@
 #include <unordered_map>
 
 #include "ApiGL/Bindings.h"
+#include "ApiGL/Types/GLMesh.h"
 
 namespace lepus
 {
@@ -64,16 +65,17 @@ namespace lepus
 		{
 			friend class GraphicsApiGLOptions;
 			private:
+			static const uint8_t _meshCount = 2;
 			struct
 			{
 				/// @brief Handle to the vertex array objects.
 				GLuint vao;
 
 				/// @brief Handle to the global VBO.
-				GLuint vbo;
+				GLuint vbo[_meshCount] = { 0, 0 };
 
 				/// @brief Handle to the global IBO.
-				GLuint ibo;
+				GLuint ibo[_meshCount] = { 0, 0 };
 
 				/// @brief List with all uniforms used by the API.
 				// TODO: Change to array - might get better cache/locality to improve access times.
@@ -85,6 +87,8 @@ namespace lepus
 			} m_Pipeline;
 
 			GLuint m_Programs[GraphicsApiGLOptions::ProgramCount];
+
+			GLMesh m_Meshes[_meshCount];
 
 			private:
 			void SetupVertexArrays();

--- a/src/lepus/gfx/GraphicsEngine/Apis/ApiGL/ApiGL.cpp
+++ b/src/lepus/gfx/GraphicsEngine/Apis/ApiGL/ApiGL.cpp
@@ -1,4 +1,5 @@
 #include "../ApiGL.h"
+#include "Types/GLMesh.h"
 #include <GL/gl3w.h>
 
 using namespace lepus::gfx;
@@ -19,19 +20,9 @@ void GraphicsApiGL::SetupBuffers()
 {
 	glBindVertexArray(m_Pipeline.vao);
 
-	// Create a global VBO and upload triangle data to it.
-	glCreateBuffers(1, &m_Pipeline.vbo);
-	//const GLfloat vertices[] = { -0.5f, -0.5f, 0.f, 0.5f, -0.5f, 0.f, 0.f, 0.5f, 0.f };
-	glBindBuffer(GL_ARRAY_BUFFER, m_Pipeline.vbo);
-	glEnableVertexAttribArray(0);
-	glVertexAttribPointer(0, 3, GL_FLOAT, GL_TRUE, 0, 0);
-	glBufferData(GL_ARRAY_BUFFER, (GLsizeiptr)m_CubeGeometry.VertexBufferSize(), m_CubeGeometry.GetVertices(), GL_STATIC_DRAW);
-
-	// Create a global IBO and upload triangle index data to it.
-	glCreateBuffers(1, &m_Pipeline.ibo);
-	//const GLuint indices[] = { 0, 1, 2 };
-	glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, m_Pipeline.ibo);
-	glBufferData(GL_ELEMENT_ARRAY_BUFFER, (GLsizeiptr)m_CubeGeometry.IndexBufferSize(), m_CubeGeometry.GetIndices(), GL_STATIC_DRAW);
+	GLMesh cubeMesh = GLMesh(lepus::utility::Primitives::Cube());
+	m_Pipeline.vbo = cubeMesh.GetVBO();
+	m_Pipeline.ibo = cubeMesh.GetIBO();
 }
 
 void GraphicsApiGL::SetupShaders()
@@ -111,7 +102,7 @@ void GraphicsApiGL::Draw()
 	glBindBuffer(GL_ARRAY_BUFFER, m_Pipeline.vbo);
 	glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, m_Pipeline.ibo);
 
-	glDrawElements(GL_TRIANGLES, (GLsizei)m_CubeGeometry.IndexCount(), GL_UNSIGNED_INT, 0);
+	glDrawElements(GL_TRIANGLES, (GLsizei)lepus::utility::Primitives::Cube().IndexCount(), GL_UNSIGNED_INT, 0);
 }
 
 void GraphicsApiGL::ClearFrameBuffer(float r, float g, float b)

--- a/src/lepus/gfx/GraphicsEngine/Apis/ApiGL/ApiGL.cpp
+++ b/src/lepus/gfx/GraphicsEngine/Apis/ApiGL/ApiGL.cpp
@@ -18,10 +18,13 @@ void GraphicsApiGL::SetupBuffers()
 {
 	glBindVertexArray(m_Pipeline.vao);
 
+	// Creating a mesh from built-in primitive geometry.
 	m_Meshes[0] = GLMesh(lepus::utility::Primitives::Cube());
 	m_Pipeline.vbo[0] = m_Meshes[0].GetVBO();
 	m_Pipeline.ibo[0] = m_Meshes[0].GetIBO();
 
+	// Creating a mesh by copying the first mesh.
+	// Vertex & index data is shared with the first mesh, but uploaded to a separate pair of OpenGL buffers.
 	m_Meshes[1] = GLMesh(m_Meshes[0]);
 	m_Pipeline.vbo[1] = m_Meshes[1].GetVBO();
 	m_Pipeline.ibo[1] = m_Meshes[1].GetIBO();

--- a/src/lepus/gfx/GraphicsEngine/Apis/ApiGL/ApiGL.cpp
+++ b/src/lepus/gfx/GraphicsEngine/Apis/ApiGL/ApiGL.cpp
@@ -1,5 +1,4 @@
 #include "../ApiGL.h"
-#include "Types/GLMesh.h"
 
 using namespace lepus::gfx;
 
@@ -19,9 +18,13 @@ void GraphicsApiGL::SetupBuffers()
 {
 	glBindVertexArray(m_Pipeline.vao);
 
-	GLMesh cubeMesh = GLMesh(lepus::utility::Primitives::Cube());
-	m_Pipeline.vbo = cubeMesh.GetVBO();
-	m_Pipeline.ibo = cubeMesh.GetIBO();
+	m_Meshes[0] = GLMesh(lepus::utility::Primitives::Cube());
+	m_Pipeline.vbo[0] = m_Meshes[0].GetVBO();
+	m_Pipeline.ibo[0] = m_Meshes[0].GetIBO();
+
+	m_Meshes[1] = GLMesh(m_Meshes[0]);
+	m_Pipeline.vbo[1] = m_Meshes[1].GetVBO();
+	m_Pipeline.ibo[1] = m_Meshes[1].GetIBO();
 }
 
 void GraphicsApiGL::SetupShaders()
@@ -98,10 +101,13 @@ void GraphicsApiGL::Draw()
 	glUseProgram(m_Programs[0]);
 
 	glBindVertexArray(m_Pipeline.vao);
-	glBindBuffer(GL_ARRAY_BUFFER, m_Pipeline.vbo);
-	glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, m_Pipeline.ibo);
+	for (uint8_t meshIndex = 0; meshIndex < _meshCount; meshIndex++)
+	{
+		glBindBuffer(GL_ARRAY_BUFFER, m_Pipeline.vbo[meshIndex]);
+		glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, m_Pipeline.ibo[meshIndex]);
 
-	glDrawElements(GL_TRIANGLES, (GLsizei)lepus::utility::Primitives::Cube().IndexCount(), GL_UNSIGNED_INT, 0);
+		glDrawElements(GL_TRIANGLES, (GLsizei)lepus::utility::Primitives::Cube().IndexCount(), GL_UNSIGNED_INT, 0);
+	}
 }
 
 void GraphicsApiGL::ClearFrameBuffer(float r, float g, float b)

--- a/src/lepus/gfx/GraphicsEngine/Apis/ApiGL/ApiGL.cpp
+++ b/src/lepus/gfx/GraphicsEngine/Apis/ApiGL/ApiGL.cpp
@@ -46,14 +46,14 @@ void GraphicsApiGL::SetupShaders()
 void GraphicsApiGL::SetupUniforms()
 {
 	// Proj matrix
-	auto* proj = new lepus::gfx::GLMatrixUniformBinding(glGetUniformLocation(m_Programs[0], "PROJ"));
+	auto* proj = new lepus::gfx::GLMatrixUniformBinding(glGetUniformLocation(m_Programs[0], LEPUS_GFX_UNIFORMS_GLOBAL_PROJECTION_MATRIX));
 	m_Pipeline.uniforms.push_front((lepus::gfx::GLUniformBinding<void*>*)(proj));
-	m_Pipeline.uniformMap.insert_or_assign("PROJ", reinterpret_cast<lepus::gfx::GLUniformBinding<void*>*>(proj));
+	m_Pipeline.uniformMap.insert_or_assign(LEPUS_GFX_UNIFORMS_GLOBAL_PROJECTION_MATRIX, reinterpret_cast<lepus::gfx::GLUniformBinding<void*>*>(proj));
 
 	// View matrix
-	auto* view = new lepus::gfx::GLMatrixUniformBinding(glGetUniformLocation(m_Programs[0], "VIEW"));
+	auto* view = new lepus::gfx::GLMatrixUniformBinding(glGetUniformLocation(m_Programs[0], LEPUS_GFX_UNIFORMS_GLOBAL_VIEW_MATRIX));
 	m_Pipeline.uniforms.push_front((lepus::gfx::GLUniformBinding<void*>*)(view));
-	m_Pipeline.uniformMap.insert_or_assign("VIEW", reinterpret_cast<lepus::gfx::GLUniformBinding<void*>*>(view));
+	m_Pipeline.uniformMap.insert_or_assign(LEPUS_GFX_UNIFORMS_GLOBAL_VIEW_MATRIX, reinterpret_cast<lepus::gfx::GLUniformBinding<void*>*>(view));
 }
 
 void GraphicsApiGL::CreatePipeline()

--- a/src/lepus/gfx/GraphicsEngine/Apis/ApiGL/ApiGL.cpp
+++ b/src/lepus/gfx/GraphicsEngine/Apis/ApiGL/ApiGL.cpp
@@ -1,6 +1,5 @@
 #include "../ApiGL.h"
 #include "Types/GLMesh.h"
-#include <GL/gl3w.h>
 
 using namespace lepus::gfx;
 

--- a/src/lepus/gfx/GraphicsEngine/Apis/ApiGL/ApiGL.cpp
+++ b/src/lepus/gfx/GraphicsEngine/Apis/ApiGL/ApiGL.cpp
@@ -109,7 +109,7 @@ void GraphicsApiGL::Draw()
 		glBindBuffer(GL_ARRAY_BUFFER, m_Pipeline.vbo[meshIndex]);
 		glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, m_Pipeline.ibo[meshIndex]);
 
-		glDrawElements(GL_TRIANGLES, (GLsizei)lepus::utility::Primitives::Cube().IndexCount(), GL_UNSIGNED_INT, 0);
+		glDrawElements(GL_TRIANGLES, (GLsizei)m_Meshes[meshIndex].IndexCount(), GL_UNSIGNED_INT, 0);
 	}
 }
 

--- a/src/lepus/gfx/GraphicsEngine/Apis/ApiGL/Types/GLMesh.h
+++ b/src/lepus/gfx/GraphicsEngine/Apis/ApiGL/Types/GLMesh.h
@@ -8,11 +8,14 @@ namespace lepus
 {
     namespace gfx
     {
-        class GLMesh : public lepus::engine::objects::Mesh
+        class GLMesh : protected lepus::engine::objects::Mesh
         {
             private:
             GLuint m_VBO;
             GLuint m_IBO;
+
+            bool m_HasVBO;
+            bool m_HasIBO;
 
             void _CreateVBO();
             void _CreateIBO();
@@ -20,15 +23,80 @@ namespace lepus
             protected:
             inline void InitInternal() override
             {
-                _CreateVBO();
-                _CreateIBO();
+                m_VBO = 0;
+                m_IBO = 0;
+                m_HasIBO = false;
+                m_HasVBO = false;
+
+                // Avoid creating a VBO or IBO if the size is 0 - this is likely because the mesh is being created on the stack
+                // before a VAO was bound. This will only result in a crash.
+                if (VertexBufferSize() > 0)
+                {
+                    _CreateVBO();
+                }
+
+                if (IndexCount() > 0)
+                {
+                    _CreateIBO();
+                }
+            }
+
+            inline void CopyInternal(const GLMesh& other)
+            {
+                Mesh::CopyInternal(other);
+                InitInternal();
             }
 
             public:
             LEPUS_MESH_CONSTRUCTOR(GLMesh);
 
+            GLMesh(const GLMesh& other)
+            {
+                CopyInternal(other);
+            }
+
+            GLMesh(GLMesh&& other)
+            {
+                *this = std::move(other);
+            }
+
+            GLMesh& operator=(const GLMesh& other)
+            {
+                CopyInternal(other);
+                return *this;
+            }
+
+            GLMesh& operator=(GLMesh&& other)
+            {
+                *((Mesh*)this) = (Mesh)other;
+
+                m_IBO = other.m_IBO;
+                m_VBO = other.m_VBO;
+                other.m_HasIBO = false;
+                other.m_HasVBO = false;
+
+                return *this;
+            }
+
             inline GLuint GetVBO() const { return m_VBO; }
             inline GLuint GetIBO() const { return m_IBO; }
+
+            inline void Dispose() override
+            {
+                Mesh::Dispose();
+
+                if (m_HasVBO)
+                {
+                    glDeleteBuffers(1, &m_VBO);
+                    m_HasVBO = false;
+                }
+
+                if (m_HasIBO)
+                {
+                    glDeleteBuffers(1, &m_IBO);
+                    m_HasIBO = false;
+                }
+            }
         };
     }
 }

--- a/src/lepus/gfx/GraphicsEngine/Apis/ApiGL/Types/GLMesh.h
+++ b/src/lepus/gfx/GraphicsEngine/Apis/ApiGL/Types/GLMesh.h
@@ -26,6 +26,9 @@ namespace lepus
 
             public:
             LEPUS_MESH_CONSTRUCTOR(GLMesh);
+
+            inline GLuint GetVBO() const { return m_VBO; }
+            inline GLuint GetIBO() const { return m_IBO; }
         };
     }
 }

--- a/src/lepus/gfx/GraphicsEngine/Apis/ApiGL/Types/GLMesh.h
+++ b/src/lepus/gfx/GraphicsEngine/Apis/ApiGL/Types/GLMesh.h
@@ -2,7 +2,7 @@
 #define LEPUS_GFX_GL_MESH
 
 #include <lepus/engine/Objects/Mesh.h>
-#include <gl/GL3w.h>
+#include <GL/gl3w.h>
 
 namespace lepus
 {

--- a/src/lepus/gfx/GraphicsEngine/Apis/ApiGL/Types/GLMesh.h
+++ b/src/lepus/gfx/GraphicsEngine/Apis/ApiGL/Types/GLMesh.h
@@ -82,12 +82,23 @@ namespace lepus
             /// @return A reference to a GLMesh object with vertex & index data as well as OpenGL buffers moved from the assigned object.
             GLMesh& operator=(GLMesh&& other)
             {
-                *((Mesh*)this) = (Mesh)other;
+                if (this != &other)
+                {
+                    Dispose();
 
-                m_IBO = other.m_IBO;
-                m_VBO = other.m_VBO;
-                other.m_HasIBO = false;
-                other.m_HasVBO = false;
+                    MoveInternal(other);
+
+                    m_IBO = other.m_IBO;
+                    m_VBO = other.m_VBO;
+                    m_HasIBO = other.m_HasIBO;
+                    m_HasVBO = other.m_HasVBO;
+
+                    other.m_HasIBO = false;
+                    other.m_HasVBO = false;
+                    other.m_IBO = 0;
+                    other.m_VBO = 0;
+                }
+
 
                 return *this;
             }

--- a/src/lepus/gfx/GraphicsEngine/Apis/ApiGL/Types/GLMesh.h
+++ b/src/lepus/gfx/GraphicsEngine/Apis/ApiGL/Types/GLMesh.h
@@ -8,6 +8,7 @@ namespace lepus
 {
     namespace gfx
     {
+        /// @brief A Mesh specialisation to create and manage OpenGL resources for mesh data as needed.
         class GLMesh : protected lepus::engine::objects::Mesh
         {
             private:
@@ -17,7 +18,9 @@ namespace lepus
             bool m_HasVBO;
             bool m_HasIBO;
 
+            /// @brief Creates a Vertex Buffer Object for the mesh data.
             void _CreateVBO();
+            /// @brief Creates an Index Buffer Object for the mesh data.
             void _CreateIBO();
 
             protected:
@@ -29,7 +32,7 @@ namespace lepus
                 m_HasVBO = false;
 
                 // Avoid creating a VBO or IBO if the size is 0 - this is likely because the mesh is being created on the stack
-                // before a VAO was bound. This will only result in a crash.
+                // with the default constructor before a VAO was bound. This will only result in a crash.
                 if (VertexBufferSize() > 0)
                 {
                     _CreateVBO();
@@ -50,22 +53,33 @@ namespace lepus
             public:
             LEPUS_MESH_CONSTRUCTOR(GLMesh);
 
+            /// @brief Copy constructor
+            /// @param other GLMesh object to copy.
             GLMesh(const GLMesh& other)
             {
                 CopyInternal(other);
             }
 
+            /// @brief Move constructor. Moves all base Mesh data (including vertices and indices) as well as OpenGL buffer names.
+            /// @param other GLMesh rvalue to move data from.
             GLMesh(GLMesh&& other)
             {
+                // Calls the move-assignment operator as the logic is the same.
                 *this = std::move(other);
             }
 
+            /// @brief Copy-assignment operator
+            /// @param other GLMesh object to copy.
+            /// @return A reference to a GLMesh object with data internally copied from the assigned object.
             GLMesh& operator=(const GLMesh& other)
             {
                 CopyInternal(other);
                 return *this;
             }
 
+            /// @brief Move-assignment operator
+            /// @param other GLMesh rvalue to move data from.
+            /// @return A reference to a GLMesh object with vertex & index data as well as OpenGL buffers moved from the assigned object.
             GLMesh& operator=(GLMesh&& other)
             {
                 *((Mesh*)this) = (Mesh)other;
@@ -78,9 +92,15 @@ namespace lepus
                 return *this;
             }
 
+            /// @brief Gets the Vertex Buffer Object used for this Mesh.
+            /// @return An OpenGL Vertex Buffer Object name that can be used with glBindBuffer.
             inline GLuint GetVBO() const { return m_VBO; }
+
+            /// @brief Gets the Index Buffer Object used for this Mesh.
+            /// @return An OpenGL Index Buffer Object name that can be used with glBindBuffer.
             inline GLuint GetIBO() const { return m_IBO; }
 
+            /// @brief Specialised Dispose() that, in addition to calling base Dispose(), releases OpenGL Vertex and Index Buffer Objects as needed.
             inline void Dispose() override
             {
                 Mesh::Dispose();

--- a/src/lepus/gfx/GraphicsEngine/Apis/ApiGL/Types/GLMesh.h
+++ b/src/lepus/gfx/GraphicsEngine/Apis/ApiGL/Types/GLMesh.h
@@ -9,7 +9,7 @@ namespace lepus
     namespace gfx
     {
         /// @brief A Mesh specialisation to create and manage OpenGL resources for mesh data as needed.
-        class GLMesh : protected lepus::engine::objects::Mesh
+        class GLMesh : public lepus::engine::objects::Mesh
         {
             private:
             GLuint m_VBO;

--- a/src/lepus/gfx/GraphicsEngine/Apis/ApiGL/Types/GLMesh.h
+++ b/src/lepus/gfx/GraphicsEngine/Apis/ApiGL/Types/GLMesh.h
@@ -1,0 +1,33 @@
+#ifndef LEPUS_GFX_GL_MESH
+#define LEPUS_GFX_GL_MESH
+
+#include <lepus/engine/Objects/Mesh.h>
+#include <gl/GL3w.h>
+
+namespace lepus
+{
+    namespace gfx
+    {
+        class GLMesh : public lepus::engine::objects::Mesh
+        {
+            private:
+            GLuint m_VBO;
+            GLuint m_IBO;
+
+            void _CreateVBO();
+            void _CreateIBO();
+
+            protected:
+            inline void InitInternal() override
+            {
+                _CreateVBO();
+                _CreateIBO();
+            }
+
+            public:
+            LEPUS_MESH_CONSTRUCTOR(GLMesh);
+        };
+    }
+}
+
+#endif

--- a/src/lepus/gfx/GraphicsEngine/Apis/ApiGL/Types/GLMesh/GLMesh.cpp
+++ b/src/lepus/gfx/GraphicsEngine/Apis/ApiGL/Types/GLMesh/GLMesh.cpp
@@ -5,20 +5,25 @@ void GLMesh::_CreateVBO()
 {
     if (GetFormat() != lepus::engine::MeshVertexFormat::Invalid)
     {
+        glBindBuffer(GL_ARRAY_BUFFER, 0);
         glCreateBuffers(1, &m_VBO);
         glBindBuffer(GL_ARRAY_BUFFER, m_VBO);
         glEnableVertexAttribArray(0);
         glVertexAttribPointer(0, 3, GL_FLOAT, GL_TRUE, 0, 0);
         glBufferData(GL_ARRAY_BUFFER, (GLsizeiptr)VertexBufferSize(), GetVertices(), GL_STATIC_DRAW);
         glBindBuffer(GL_ARRAY_BUFFER, 0);
+
+        m_HasVBO = true;
     }
 }
 
 void GLMesh::_CreateIBO()
 {
     // Create an IBO and upload index data to it.
+    glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0);
     glCreateBuffers(1, &m_IBO);
     glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, m_IBO);
     glBufferData(GL_ELEMENT_ARRAY_BUFFER, (GLsizeiptr)IndexBufferSize(), GetIndices(), GL_STATIC_DRAW);
     glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0);
+    m_HasIBO = true;
 }

--- a/src/lepus/gfx/GraphicsEngine/Apis/ApiGL/Types/GLMesh/GLMesh.cpp
+++ b/src/lepus/gfx/GraphicsEngine/Apis/ApiGL/Types/GLMesh/GLMesh.cpp
@@ -1,0 +1,24 @@
+#include "../GLMesh.h"
+using namespace lepus::gfx;
+
+void GLMesh::_CreateVBO()
+{
+    if (GetFormat() != lepus::engine::MeshVertexFormat::Invalid)
+    {
+        glCreateBuffers(1, &m_VBO);
+        glBindBuffer(GL_ARRAY_BUFFER, m_VBO);
+        glEnableVertexAttribArray(0);
+        glVertexAttribPointer(0, 3, GL_FLOAT, GL_TRUE, 0, 0);
+        glBufferData(GL_ARRAY_BUFFER, (GLsizeiptr)VertexBufferSize(), GetVertices(), GL_STATIC_DRAW);
+        glBindBuffer(GL_ARRAY_BUFFER, 0);
+    }
+}
+
+void GLMesh::_CreateIBO()
+{
+    // Create an IBO and upload index data to it.
+    glCreateBuffers(1, &m_IBO);
+    glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, m_IBO);
+    glBufferData(GL_ELEMENT_ARRAY_BUFFER, (GLsizeiptr)IndexBufferSize(), GetIndices(), GL_STATIC_DRAW);
+    glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0);
+}

--- a/src/lepus/utility/Primitives.h
+++ b/src/lepus/utility/Primitives.h
@@ -3,6 +3,7 @@
 
 #include <cassert>
 #include <memory>
+#include <cstring>
 
 namespace lepus
 {

--- a/src/lepus/utility/Primitives.h
+++ b/src/lepus/utility/Primitives.h
@@ -4,201 +4,217 @@
 #include <cassert>
 #include <memory>
 
-namespace LepusUtility
+namespace lepus
 {
-    class Primitive
+    namespace utility
     {
-        private:
-        float* m_Verts;
-        size_t m_VertCount;
-        uint32_t* m_Indices;
-        size_t m_IndexCount;
-
-        public:
-        /// @brief Number of floats for each vertex. Currently, we only store position (XYZ).
-        static const unsigned char NbComponents = 3;
-
-        // Move constructor
-        Primitive(Primitive&& other)
+        class Primitive
         {
-            Primitive();
+            private:
+            float* m_Verts;
+            size_t m_VertCount;
+            uint32_t* m_Indices;
+            size_t m_IndexCount;
 
-            m_Verts = other.m_Verts;
-            m_VertCount = other.m_VertCount;
-            m_Indices = other.m_Indices;
-            m_IndexCount = other.m_IndexCount;
+            public:
+            /// @brief Number of floats for each vertex. Currently, we only store position (XYZ).
+            static const unsigned char NbComponents = 3;
 
-            // Prevent the moved resource from altering the pointers.
-            other.m_Verts = nullptr;
-            other.m_Indices = nullptr;
-        }
-
-        Primitive& operator=(Primitive&& other)
-        {
-            if (this != &other)
+            // Move constructor
+            Primitive(Primitive&& other)
             {
-                if (m_Verts)
-                {
-                    delete[] m_Verts;
-                }
-
-                if (m_Indices)
-                {
-                    delete[] m_Indices;
-                }
+                Primitive();
 
                 m_Verts = other.m_Verts;
-                m_Indices = other.m_Indices;
                 m_VertCount = other.m_VertCount;
+                m_Indices = other.m_Indices;
                 m_IndexCount = other.m_IndexCount;
+
+                // Prevent the moved resource from altering the pointers.
+                other.m_Verts = nullptr;
+                other.m_Indices = nullptr;
             }
 
-            return *this;
-        }
+            Primitive& operator=(Primitive&& other)
+            {
+                if (this != &other)
+                {
+                    if (m_Verts)
+                    {
+                        delete[] m_Verts;
+                    }
 
-        /// @brief Creates a new primitive with the provided vertices.
-        /// @param vertexPositions Array of tightly packed XYZ positions for each vertex.
-        /// @param nbVertexPositions Number of vertex positions - do not confuse with length of vertexPositions.
-        Primitive(const float* const vertexPositions, size_t nbVertexPositions, const uint32_t* const indices, size_t nbIndices)
+                    if (m_Indices)
+                    {
+                        delete[] m_Indices;
+                    }
+
+                    m_Verts = other.m_Verts;
+                    m_Indices = other.m_Indices;
+                    m_VertCount = other.m_VertCount;
+                    m_IndexCount = other.m_IndexCount;
+                }
+
+                return *this;
+            }
+
+            /// @brief Creates a new primitive with the provided vertices.
+            /// @param vertexPositions Array of tightly packed XYZ positions for each vertex.
+            /// @param nbVertexPositions Number of vertex positions - do not confuse with length of vertexPositions.
+            Primitive(const float* const vertexPositions, size_t nbVertexPositions, const uint32_t* const indices, size_t nbIndices)
+            {
+                m_Verts = nullptr;
+                m_VertCount = 0;
+                m_Indices = nullptr;
+                m_IndexCount = 0;
+
+                Init(vertexPositions, nbVertexPositions, indices, nbIndices);
+            }
+
+            Primitive()
+            {
+                m_Verts = nullptr;
+                m_VertCount = 0;
+                m_Indices = nullptr;
+                m_IndexCount = 0;
+            }
+
+            /// @brief Initialises the primitive with the provided vertices.
+            /// @param vertexPositions Array of tightly packed XYZ positions for each vertex.
+            /// @param nbVertexPositions Number of vertex positions - do not confuse with length of vertexPositions.
+            void Init(const float* const vertexPositions, size_t nbVertexPositions, const uint32_t* const indices, size_t nbIndices)
+            {
+                assert(m_Verts == nullptr);
+
+                m_Verts = new float[nbVertexPositions * NbComponents];
+                m_VertCount = nbVertexPositions;
+                memcpy(m_Verts, vertexPositions, nbVertexPositions * NbComponents * sizeof(float));
+
+                m_Indices = new uint32_t[nbIndices];
+                m_IndexCount = nbIndices;
+                memcpy(m_Indices, indices, nbIndices * sizeof(uint32_t));
+            }
+
+            const float* GetVertices() const
+            {
+                return m_Verts;
+            }
+
+            const uint32_t* GetIndices() const
+            {
+                return m_Indices;
+            }
+
+            const size_t inline VertexCount() const
+            {
+                return m_VertCount;
+            }
+
+            constexpr size_t const inline VertexBufferSize() const
+            {
+                return m_VertCount * sizeof(float) * NbComponents;
+            }
+
+            constexpr size_t const inline IndexBufferSize() const
+            {
+                return m_IndexCount * sizeof(uint32_t);
+            }
+
+            const size_t inline IndexCount() const
+            {
+                return m_IndexCount;
+            }
+        };
+
+        class Primitives
         {
-            m_Verts = nullptr;
-            m_VertCount = 0;
-            m_Indices = nullptr;
-            m_IndexCount = 0;
+            private:
+            static Primitives _shared;
+            public:
+            static Primitives& Shared() { return _shared; };
 
-            Init(vertexPositions, nbVertexPositions, indices, nbIndices);
-        }
+#define LEPUS_UTILITY_PRIMITIVE_SHARED(PrimitiveName) \
+private:\
+Primitive m_ ## PrimitiveName ## Instance = Create ## PrimitiveName(); \
+public:\
+static const inline Primitive& PrimitiveName() {return Shared().m_ ## PrimitiveName ## Instance;}
 
-        Primitive()
-        {
-            m_Verts = nullptr;
-            m_VertCount = 0;
-            m_Indices = nullptr;
-            m_IndexCount = 0;
-        }
+            public:
+            static const inline Primitive CreateCube()
+            {
+                // Assuming negative left and negative up
+                const float cubeVertices[] = {
+                    // Front:
+                    -0.5f, 0.5f, -0.5f, // top-left (0)
+                    0.5f, 0.5f, -0.5f, // top-right (1)
+                    -0.5f, -0.5f, -0.5f, // bottom-left (2)
+                    0.5f, -0.5f, -0.5f, // bottom-right (3)
 
-        /// @brief Initialises the primitive with the provided vertices.
-        /// @param vertexPositions Array of tightly packed XYZ positions for each vertex.
-        /// @param nbVertexPositions Number of vertex positions - do not confuse with length of vertexPositions.
-        void Init(const float* const vertexPositions, size_t nbVertexPositions, const uint32_t* const indices, size_t nbIndices)
-        {
-            assert(m_Verts == nullptr);
+                    // Left:
+                    -0.5f, 0.5f, 0.5f, // top-left (4)
+                    // use front top-left (0) as top-right
+                    -0.5f, -0.5f, 0.5f, // bottom-left (5)
+                    // use front bottom-left (2) as bottom-right
 
-            m_Verts = new float[nbVertexPositions * NbComponents];
-            m_VertCount = nbVertexPositions;
-            memcpy(m_Verts, vertexPositions, nbVertexPositions * NbComponents * sizeof(float));
+                    // Back:
+                    0.5f, 0.5f, 0.5f, // top-left (6)
+                    // reuse left top-left (4) as top-right
+                    0.5f, -0.5f, 0.5f, // bottom-left (7)
+                    // use left bottom-left (5) as bottom-right
 
-            m_Indices = new uint32_t[nbIndices];
-            m_IndexCount = nbIndices;
-            memcpy(m_Indices, indices, nbIndices * sizeof(uint32_t));
-        }
+                    // Top:
+                    // use left top-left (4) as top-left
+                    // use back top-left (6) as top-right
+                    // use left top-right (0) as bottom-left
+                    // use front top-right (1) as bottom-right
 
-        const float* GetVertices()
-        {
-            return m_Verts;
-        }
+                    // Right:
+                    // use front top-right (1) as top-left
+                    // use back top-left (6) as top-right
+                    // use front bottom-right (3) as bottom-left
+                    // use back bottom-left (7) as bottom-right
 
-        const uint32_t* GetIndices()
-        {
-            return m_Indices;
-        }
+                    // Bottom:
+                    // use front bottom-left (2) as top-left
+                    // use front bottom-right (3) as top-right
+                    // use back bottom-right (5) as bottom-left
+                    // use back bottom-left (7) as bottom-right
+                };
 
-        const size_t inline VertexCount()
-        {
-            return m_VertCount;
-        }
-
-        constexpr size_t const inline VertexBufferSize()
-        {
-            return m_VertCount * sizeof(float) * NbComponents;
-        }
-
-        constexpr size_t const inline IndexBufferSize()
-        {
-            return m_IndexCount * sizeof(uint32_t);
-        }
-
-        const size_t inline IndexCount()
-        {
-            return m_IndexCount;
-        }
-    };
-
-    class Primitives
-    {
-        public:
-        static const inline Primitive Cube()
-        {
-            // Assuming negative left and negative up
-            const float cubeVertices[] = {
-                // Front:
-                -0.5f, 0.5f, -0.5f, // top-left (0)
-                0.5f, 0.5f, -0.5f, // top-right (1)
-                -0.5f, -0.5f, -0.5f, // bottom-left (2)
-                0.5f, -0.5f, -0.5f, // bottom-right (3)
-
-                // Left:
-                -0.5f, 0.5f, 0.5f, // top-left (4)
-                // use front top-left (0) as top-right
-                -0.5f, -0.5f, 0.5f, // bottom-left (5)
-                // use front bottom-left (2) as bottom-right
-
-                // Back:
-                0.5f, 0.5f, 0.5f, // top-left (6)
-                // reuse left top-left (4) as top-right
-                0.5f, -0.5f, 0.5f, // bottom-left (7)
-                // use left bottom-left (5) as bottom-right
-
-                // Top:
-                // use left top-left (4) as top-left
-                // use back top-left (6) as top-right
-                // use left top-right (0) as bottom-left
-                // use front top-right (1) as bottom-right
-
-                // Right:
-                // use front top-right (1) as top-left
-                // use back top-left (6) as top-right
-                // use front bottom-right (3) as bottom-left
-                // use back bottom-left (7) as bottom-right
-
-                // Bottom:
-                // use front bottom-left (2) as top-left
-                // use front bottom-right (3) as top-right
-                // use back bottom-right (5) as bottom-left
-                // use back bottom-left (7) as bottom-right
-            };
-
-            const uint32_t indices[] = {
-                // Front:
-                1, 3, 0,
-                3, 2, 0,
+                const uint32_t indices[] = {
+                    // Front:
+                    1, 3, 0,
+                    3, 2, 0,
 
 
-                // Left:
-                0, 2, 4,
-                2, 5, 4,
+                    // Left:
+                    0, 2, 4,
+                    2, 5, 4,
 
 
-                // Back:
-                5, 6, 4,
-                5, 7, 6,
+                    // Back:
+                    5, 6, 4,
+                    5, 7, 6,
 
-                // Top:
-                1, 4, 6,
-                1, 0, 4,
+                    // Top:
+                    1, 4, 6,
+                    1, 0, 4,
 
-                // Right:
-                7, 1, 6,
-                7, 3, 1,
+                    // Right:
+                    7, 1, 6,
+                    7, 3, 1,
 
-                // Bottom:
-                7, 2, 3,
-                7, 5, 2
-            };
+                    // Bottom:
+                    7, 2, 3,
+                    7, 5, 2
+                };
 
-            return Primitive(cubeVertices, sizeof(cubeVertices) / sizeof(float) / 3, indices, sizeof(indices) / sizeof(uint32_t));
-        }
-    };
+                return Primitive(cubeVertices, sizeof(cubeVertices) / sizeof(float) / 3, indices, sizeof(indices) / sizeof(uint32_t));
+            }
+
+            LEPUS_UTILITY_PRIMITIVE_SHARED(Cube);
+        };
+    }
 }
 
 #endif

--- a/src/lepus/utility/Primitives.h
+++ b/src/lepus/utility/Primitives.h
@@ -106,22 +106,22 @@ namespace lepus
                 return m_Indices;
             }
 
-            const size_t inline VertexCount() const
+            size_t inline VertexCount() const
             {
                 return m_VertCount;
             }
 
-            constexpr size_t const inline VertexBufferSize() const
+            size_t inline VertexBufferSize() const
             {
                 return m_VertCount * sizeof(float) * NbComponents;
             }
 
-            constexpr size_t const inline IndexBufferSize() const
+            size_t inline IndexBufferSize() const
             {
                 return m_IndexCount * sizeof(uint32_t);
             }
 
-            const size_t inline IndexCount() const
+            size_t inline IndexCount() const
             {
                 return m_IndexCount;
             }

--- a/src/lepus/utility/Primitives.h
+++ b/src/lepus/utility/Primitives.h
@@ -132,6 +132,9 @@ namespace lepus
             private:
             static Primitives _shared;
             public:
+
+            /// @brief Gets the global Primitives instance.
+            /// @return A reference to the global Primitives object containing shared instances of Primitive objects.
             static Primitives& Shared() { return _shared; };
 
 #define LEPUS_UTILITY_PRIMITIVE_SHARED(PrimitiveName) \

--- a/src/lepus/utility/Primitives/Shared.cpp
+++ b/src/lepus/utility/Primitives/Shared.cpp
@@ -1,0 +1,5 @@
+#include "../Primitives.h"
+
+using namespace lepus::utility;
+
+Primitives Primitives::_shared = Primitives();


### PR DESCRIPTION
This PR adds a common `Mesh` class used to represent mesh data within the engine, and a `GLMesh` class derived from it in order to simplify uploading geometry data to OpenGL buffers.

Going forward this will be used by scene graphs and resource managers to control how data is instantiated and consumed.

Closes #31 